### PR TITLE
Fixed warning for clip styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -331,6 +331,7 @@ Resource card
   font-size: 8rem;
   background: url(/public/images/rpg.webp);
   background-size: contain;
+  background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   text-align: center;


### PR DESCRIPTION
# Description

Updated the index.css file > RPG class to include the default background-clip attribute with a 'text' value.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
